### PR TITLE
Link proxy replacements now support missing text quotes

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -13,8 +13,8 @@ class Response
 		$this->html = $this->origHtml = $html;
 
 		// Fix links that don't use quotes
-		$this->html = preg_replace_callback('/(src|href)=([^"\']*?)\s/', function ($matches) {
-			return $matches[1] . '="' . $matches[2] . '" ';
+		$this->html = preg_replace_callback('/(src|href)=([^"\']*?)(\s|>)/', function ($matches) {
+			return $matches[1] . '="' . $matches[2] . '"' . $matches[3];
 		}, $this->html);
 	}
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -11,6 +11,11 @@ class Response
 	public function __construct($html)
 	{
 		$this->html = $this->origHtml = $html;
+
+		// Fix links that don't use quotes
+		$this->html = preg_replace_callback('/(src|href)=([^"\']*?)\s/', function ($matches) {
+			return $matches[1] . '="' . $matches[2] . '" ';
+		}, $this->html);
 	}
 
 	public function setProxyPath($path)

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -26,9 +26,9 @@ class ResponseTest extends TestCase
 			<script src="js/demo.js"></script>
 
 			<link rel="stylesheet" href="/css/main.css">
-            <!-- Angular Specific -->
-            <link rel=preload href=/css/main.css as=style crossorigin>
-            <link rel=preload href=/css/main.css?1606323568292 as=style crossorigin>
+			<!-- Angular Specific -->
+			<link rel=preload href=/css/main.css as=style crossorigin>
+			<link rel=preload href=/css/main.css?1606323568292 as=style crossorigin>
 
 			body {
 				background: url(/image/something.png);
@@ -58,9 +58,9 @@ class ResponseTest extends TestCase
 			<script src="http://demo.com/proxy/js/demo.js"></script>
 
 			<link rel="stylesheet" href="http://demo.com/proxy/css/main.css">
-            <!-- Angular Specific -->
-            <link rel=preload href="http://demo.com/proxy/css/main.css" as=style crossorigin>
-            <link rel=preload href="http://demo.com/proxy/css/main.css?1606323568292" as=style crossorigin>
+			<!-- Angular Specific -->
+			<link rel=preload href="http://demo.com/proxy/css/main.css" as=style crossorigin>
+			<link rel=preload href="http://demo.com/proxy/css/main.css?1606323568292" as=style crossorigin>
 
 			body {
 				background: url(http://demo.com/proxy/image/something.png);

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -29,6 +29,7 @@ class ResponseTest extends TestCase
 			<!-- Angular Specific -->
 			<link rel=preload href=/css/main.css as=style crossorigin>
 			<link rel=preload href=/css/main.css?1606323568292 as=style crossorigin>
+			<link rel=stylesheet href=/css/main.css>
 
 			body {
 				background: url(/image/something.png);
@@ -61,6 +62,7 @@ class ResponseTest extends TestCase
 			<!-- Angular Specific -->
 			<link rel=preload href="http://demo.com/proxy/css/main.css" as=style crossorigin>
 			<link rel=preload href="http://demo.com/proxy/css/main.css?1606323568292" as=style crossorigin>
+			<link rel=stylesheet href="http://demo.com/proxy/css/main.css">
 
 			body {
 				background: url(http://demo.com/proxy/image/something.png);

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -21,11 +21,14 @@ class ResponseTest extends TestCase
 
 			<img src="/img/something.png" alt="abc">
 			<img src="http://ajax.googleapis.com/something.png">
-			
+
 			<script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 			<script src="js/demo.js"></script>
 
 			<link rel="stylesheet" href="/css/main.css">
+            <!-- Angular Specific -->
+            <link rel=preload href=/css/main.css as=style crossorigin>
+            <link rel=preload href=/css/main.css?1606323568292 as=style crossorigin>
 
 			body {
 				background: url(/image/something.png);
@@ -50,11 +53,14 @@ class ResponseTest extends TestCase
 
 			<img src="http://demo.com/proxy/img/something.png" alt="abc">
 			<img src="http://ajax.googleapis.com/something.png">
-			
+
 			<script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 			<script src="http://demo.com/proxy/js/demo.js"></script>
 
 			<link rel="stylesheet" href="http://demo.com/proxy/css/main.css">
+            <!-- Angular Specific -->
+            <link rel=preload href="http://demo.com/proxy/css/main.css" as=style crossorigin>
+            <link rel=preload href="http://demo.com/proxy/css/main.css?1606323568292" as=style crossorigin>
 
 			body {
 				background: url(http://demo.com/proxy/image/something.png);


### PR DESCRIPTION
Noticed that certain links weren't being proxied correctly when there were no quotes around the src/href e.g. `<link rel=stylesheet href=/css/main.css>`.

Made a quick change in the Response class to convert these links to use quotes so that they can be proxied correctly later on e.g. `<link rel=stylesheet href=/css/main.css>` becomes `<link rel="stylesheet" href="/css/main.css">`.

Updated Unit Tests to also check that this works :)