### PR TITLE
Javascript variable parsing fix

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -13,8 +13,8 @@ class Response
 		$this->html = $this->origHtml = $html;
 
 		// Fix links that don't use quotes
-		$this->html = preg_replace_callback('/(src|href)=([^"\']*?)(\s|>)/', function ($matches) {
-			return $matches[1] . '="' . $matches[2] . '"' . $matches[3];
+		$this->html = preg_replace_callback('/\s(src|href)=([^"\']*?)(\s|>)/', function ($matches) {
+			return ' ' . $matches[1] . '="' . $matches[2] . '"' . $matches[3];
 		}, $this->html);
 	}
 

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -40,6 +40,9 @@ class ResponseTest extends TestCase
 				background: url("//ajax.googleapis.com/something.png");
 				background: url("http://www.wildfireinternet.co.uk/something.png");
 			}
+			<script>
+				window.location.href=e;
+			</script>
 		';
 		$expected = '
 			Nice to talk about /Home.html and not have it replaced...
@@ -73,6 +76,9 @@ class ResponseTest extends TestCase
 				background: url("//ajax.googleapis.com/something.png");
 				background: url("http://demo.com/proxy/something.png");
 			}
+			<script>
+				window.location.href=e;
+			</script>
 		';
 		$res = new Response($html);
 		$res->setProxyPath('http://demo.com/proxy/');


### PR DESCRIPTION
The recent fix for parsing href/src attributes that don't use quotes was causing some javascript to parsed incorrectly.

For instance `window.location.href=e` was being converted into `window.location.href="http://www.demo.com/e"`.

Fixed by modifying the quote adding regex to only select href/src's that are preceded by a space character.